### PR TITLE
Snippets

### DIFF
--- a/src/scheduled/airtable/index.js
+++ b/src/scheduled/airtable/index.js
@@ -59,6 +59,10 @@ const apiSources = [
     key: "hosts",
     url: "https://api.airtable.com/v0/app2OnBmhVD4GZ68L/Hosts",
   },
+  {
+    key: "snippets",
+    url: "https://api.airtable.com/v0/app2OnBmhVD4GZ68L/Snippets",
+  },
 ];
 
 /**
@@ -116,6 +120,30 @@ exports.handler = async (req) => {
       return {
         id,
         urls: urls_rollup,
+      };
+    });
+
+  // Reformat snippets for downstream usage.
+  const snippets = airData.snippets.records
+    .filter((snippet) => {
+      const { id, placement, text } = snippet.fields;
+
+      // Filter out snippets that are incomplete.
+      const checks = [
+        id && id.trim() !== "",
+        placement && placement.trim() !== "",
+        text && text.trim() !== "",
+      ];
+
+      return checks.every((check) => check === true);
+    })
+    .map((snippet) => {
+      const { placement, text, language, host_ids } = snippet.fields;
+      return {
+        placement,
+        text,
+        language,
+        host_ids,
       };
     });
 
@@ -188,6 +216,7 @@ exports.handler = async (req) => {
     targets,
     throttles,
     hosts,
+    snippets,
   };
 
   const s3LiveCommand = new PutObjectCommand({

--- a/src/shared/links.js
+++ b/src/shared/links.js
@@ -62,29 +62,22 @@ const addAnalytics = (linkUrl, analytics, hostDef) => {
  * A processed list of target links in the requested language.
  */
 exports.assembleLinks = (targets, language, hostDef) => {
-  // Unless it's Chinese, strip the language code down to two characters.
-  // We need to preserve the Chinese code to display Traditional vs. Simplified.
-  const langKey = language.startsWith("zh") ? language : language.slice(0, 2);
-
   // Return a single set of values for each link, based on language.
   // Default to English where values are unavailable.
   const links = targets.map((target) => {
     const { id, translations } = target;
 
+    const translation = translations[language];
+    const { en } = translations;
+
     // Get the SVG markup for the icon.
-    const iconKey = translations[langKey]?.icon || translations.en.icon;
+    const iconKey = translation?.icon || en.icon;
     const graphic = icons[iconKey];
 
-    const lead = translations[langKey]?.lead || translations.en.lead || "";
-
-    const catalyst =
-      translations[langKey]?.catalyst || translations.en.catalyst || "";
-
-    const linkUrl = translations[langKey]?.url || translations.en.url || "";
-
-    const analytics =
-      translations[langKey]?.analytics || translations.en.analytics || "";
-
+    const lead = translation?.lead || en.lead || "";
+    const catalyst = translation?.catalyst || en.catalyst || "";
+    const linkUrl = translation?.url || en.url || "";
+    const analytics = translation?.analytics || en.analytics || "";
     const urlWithAnalytics = addAnalytics(linkUrl, analytics, hostDef);
 
     return {
@@ -92,7 +85,7 @@ exports.assembleLinks = (targets, language, hostDef) => {
       catalyst,
       url: urlWithAnalytics,
       graphic,
-      language: langKey,
+      language,
       id,
     };
   });

--- a/src/shared/s3.js
+++ b/src/shared/s3.js
@@ -19,6 +19,8 @@ const s3 = new S3Client({});
  * A list of active target link throttles.
  * @property {Host[]} hosts
  * A list of hosts where the widget is placed.
+ * @property {Snippet[]} snippets
+ * A list of misc. values for use within the widget.
  */
 
 /**
@@ -79,6 +81,19 @@ const s3 = new S3Client({});
  * The id of the host.
  * @property {string[]} urls
  * The URLs associated with this host.
+ */
+
+/**
+ * A *Snippet* is a small misc. value that appears somewhere in the widget.
+ * @typedef {object} Snippet
+ * @property {string} placement
+ * The placement spot in the widget.
+ * @property {string} text
+ * The value of this snippet.
+ * @property {string} language
+ * The language code for this snippet.
+ * @property {string[]} host_ids
+ * Host IDs on which this snippet should specifically be used.
  */
 
 /**

--- a/src/shared/snippets.js
+++ b/src/shared/snippets.js
@@ -1,0 +1,47 @@
+/**
+ * Assembles snippets for this request based on language and host.
+ * @param {import('./s3.js').Snippet[]} snippetDefs
+ * Raw snippet definitions from the S3 definitons file.
+ * @param {string} language
+ * The language code for this request.
+ * @param {import('./s3.js').Host} hostDef
+ * The identified host definition for this request.
+ * @returns {object}
+ */
+exports.assembleSnippets = (snippetDefs, language, hostDef) => {
+  // Sort all snippet definitions based on relevance to language and host.
+  const sortedSnippetDefs = snippetDefs
+    .map((snippetDef) => {
+      // Let's rank 'em.
+      let rank = 0;
+
+      // Language supercedes all.
+      if (language === snippetDef?.language) rank += 5;
+
+      // Give non-host-specific snippets a small boost, to make them default.
+      if (!snippetDef.host_ids) rank += 1;
+
+      // Give host-match snippets a bigger boost, to overcome defaults.
+      if (snippetDef?.host_ids?.includes(hostDef.id)) rank += 2;
+
+      return { rank, snippetDef };
+    })
+    .sort((a, b) => b.rank - a.rank)
+    .map((rankedSnippetDef) => rankedSnippetDef.snippetDef);
+
+  // Find highest ranked snippet for each placement.
+
+  const header = sortedSnippetDefs.find(
+    (snippetDef) => snippetDef.placement === "header"
+  ).text;
+
+  const tagline = sortedSnippetDefs.find(
+    (snippetDef) => snippetDef.placement === "tagline"
+  ).text;
+
+  const experimentName = sortedSnippetDefs.find(
+    (snippetDef) => snippetDef.placement === "experiment_name"
+  ).text;
+
+  return { header, tagline, experimentName };
+};

--- a/src/shared/snippets.js
+++ b/src/shared/snippets.js
@@ -22,7 +22,7 @@ exports.assembleSnippets = (snippetDefs, language, hostDef) => {
       if (!snippetDef.host_ids) rank += 1;
 
       // Give host-match snippets a bigger boost, to overcome defaults.
-      if (snippetDef?.host_ids?.includes(hostDef.id)) rank += 2;
+      if (hostDef && snippetDef?.host_ids?.includes(hostDef?.id)) rank += 2;
 
       return { rank, snippetDef };
     })
@@ -33,15 +33,15 @@ exports.assembleSnippets = (snippetDefs, language, hostDef) => {
 
   const header = sortedSnippetDefs.find(
     (snippetDef) => snippetDef.placement === "header"
-  ).text;
+  )?.text;
 
   const tagline = sortedSnippetDefs.find(
     (snippetDef) => snippetDef.placement === "tagline"
-  ).text;
+  )?.text;
 
   const experimentName = sortedSnippetDefs.find(
     (snippetDef) => snippetDef.placement === "experiment_name"
-  ).text;
+  )?.text;
 
   return { header, tagline, experimentName };
 };


### PR DESCRIPTION
This PR brings more content from a new Airtable table (`Snippets`) into the widget. 

The `Snippets` table covers various other content throughout the widget that's not related to links, such as heading and sub-heading.