### PR TITLE
Uniform mobile wrapping

### DIFF
--- a/src/shared/templates.js
+++ b/src/shared/templates.js
@@ -89,12 +89,19 @@ ul.link-list li {
 
 ul.link-list li a {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex-direction: row;
   justify-content: space-between;
   gap: var(--benefits-recs-card-gap);
   padding: var(--benefits-recs-card-padding);
   text-decoration: none;
   color: #000;
+}
+
+@media (max-width: 43.75rem) {
+  ul.link-list li a {
+    flex-direction: column;
+  }
 }
 
 ul.link-list li a:hover {


### PR DESCRIPTION
At smaller screen sizes, the two halves of the widget links wrap. Currently, that wrapping happens based on content. We want to see how it looks if the wrapping happens across all links at once.