### PR TITLE
Log API details with events

### DIFF
--- a/.github/workflows/deploy_pr.yml
+++ b/.github/workflows/deploy_pr.yml
@@ -34,4 +34,4 @@ jobs:
           message: |
             [Widget preview page.](https://staging.cdn.innovation.ca.gov/br/pr/${{ env.URLSAFE_BRANCH_NAME }}/preview/index.html)
 
-            (You may need to wait a minute or two for the latest preview to appear at the above link.)
+            (You may need to wait a minute or two for the latest preview to appear. This page will expire when the PR is merged.)

--- a/src/http/get-benefits/index.js
+++ b/src/http/get-benefits/index.js
@@ -70,8 +70,18 @@ exports.handler = arc.http.async(async (req) => {
   const data = {
     header: snippets.header || "Apply for more benefits!",
     tagline: snippets.tagline || "You might be able to get:",
-    experimentName: snippets.experimentName || "2023-08-01-resume-tracking",
-    experimentVariation: links.map((link) => link.id).join("-"),
+    apiData: {
+      experimentName: snippets.experimentName || "2023-08-01-resume-tracking",
+      experimentVariation: links.map((link) => link.id).join("-"),
+      host: {
+        query: hostQuery,
+        definitionId: hostDef?.id,
+      },
+      language: {
+        query: langQuery,
+        translationKey: language,
+      },
+    },
     links,
   };
 

--- a/src/shared/templates.js
+++ b/src/shared/templates.js
@@ -159,8 +159,8 @@ const defaultHtml = (data) => {
   return /* html */ `
     <section 
       aria-label="benefits recommendations"
-      data-experimentName="${data.experimentName}"
-      data-experimentVariation="${data.experimentVariation}"
+      data-experimentName="${data.apiData.experimentName}"
+      data-experimentVariation="${data.apiData.experimentVariation}"
     >
       <h2>${data.header}</h2>
       <p class="tagline">${data.tagline}</p>
@@ -171,10 +171,21 @@ const defaultHtml = (data) => {
   `;
 };
 
+const defaultData = (data) => {
+  const { apiData } = data;
+
+  return /* html */ `
+    <script id="data" type="application/json">
+      ${JSON.stringify(apiData)}
+    </script>
+  `;
+};
+
 const defaultTemplate = (data) => /* html */ `
   <style>
     ${defaultCss}
   </style>
+  ${defaultData(data)}
   ${defaultHtml(data)}
 `;
 

--- a/widget/src/cagov-benefits-recs.js
+++ b/widget/src/cagov-benefits-recs.js
@@ -22,11 +22,7 @@ export class CaGovBenefitsRecs extends window.HTMLElement {
     });
 
     // Retrieve set of benefits links from API.
-    fetch(benefitsUrl.href, {
-      headers: {
-        Accept: "text/html",
-      },
-    })
+    fetch(benefitsUrl.href, { headers: { Accept: "text/html" } })
       .then(async (response) => {
         const html = await response.text();
 
@@ -34,10 +30,9 @@ export class CaGovBenefitsRecs extends window.HTMLElement {
         if (html && response.ok) {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.innerHTML = html;
-          const section = this.shadowRoot.querySelector("section");
 
-          this.experimentName = section.dataset.experimentName;
-          this.experimentVariation = section.dataset.experimentVariation;
+          const apiDataEl = this.shadowRoot.querySelector("#data");
+          this.apiData = apiDataEl ? JSON.parse(apiDataEl.textContent) : {};
 
           this.recordEvent("render");
           this.applyListeners();
@@ -57,8 +52,7 @@ export class CaGovBenefitsRecs extends window.HTMLElement {
       userAgent: navigator.userAgent,
       language: this.language,
       income: this.income,
-      experimentName: this.experimentName,
-      experimentVariation: this.experimentVariation,
+      apiData: this.apiData,
     };
 
     const data = Object.assign({ event }, defaults, details);


### PR DESCRIPTION
We need better logging to troubleshoot problems in the wild.

This PR logs details from the API call alongside each event (renders and clicks). This will allow us to see how the API interprets various inputs (language, host page, etc.) when determining what to display.