### PR TITLE
Use data attributes instead of JSON

### DIFF
--- a/src/http/get-benefits/index.js
+++ b/src/http/get-benefits/index.js
@@ -70,17 +70,15 @@ exports.handler = arc.http.async(async (req) => {
   const data = {
     header: snippets.header || "Apply for more benefits!",
     tagline: snippets.tagline || "You might be able to get:",
-    apiData: {
-      experimentName: snippets.experimentName || "2023-08-01-resume-tracking",
-      experimentVariation: links.map((link) => link.id).join("-"),
-      host: {
-        query: hostQuery,
-        definitionId: hostDef?.id,
-      },
-      language: {
-        query: langQuery,
-        translationKey: language,
-      },
+    experimentName: snippets.experimentName || "2023-08-01-resume-tracking",
+    experimentVariation: links.map((link) => link.id).join("-"),
+    host: {
+      query: hostQuery,
+      selection: hostDef?.id || "null",
+    },
+    language: {
+      query: langQuery,
+      selection: language,
     },
     links,
   };

--- a/src/http/post-event/index.js
+++ b/src/http/post-event/index.js
@@ -35,6 +35,7 @@ exports.handler = arc.http(async (req) => {
     if (!postData.displayURL) throw ReferenceError("missing displayUrl");
 
     const { apiData } = postData;
+
     if (postData.apiData) {
       delete postData.apiData;
     }

--- a/src/shared/templates.js
+++ b/src/shared/templates.js
@@ -159,8 +159,12 @@ const defaultHtml = (data) => {
   return /* html */ `
     <section 
       aria-label="benefits recommendations"
-      data-experimentName="${data.apiData.experimentName}"
-      data-experimentVariation="${data.apiData.experimentVariation}"
+      data-experiment-name="${data.experimentName}"
+      data-experiment-variation="${data.experimentVariation}"
+      data-host-query="${data.host.query}"
+      data-host-selection="${data.host.selection}"
+      data-language-query="${data.language.query}"
+      data-language-selection="${data.language.selection}"
     >
       <h2>${data.header}</h2>
       <p class="tagline">${data.tagline}</p>
@@ -171,21 +175,10 @@ const defaultHtml = (data) => {
   `;
 };
 
-const defaultData = (data) => {
-  const { apiData } = data;
-
-  return /* html */ `
-    <script id="data" type="application/json">
-      ${JSON.stringify(apiData)}
-    </script>
-  `;
-};
-
 const defaultTemplate = (data) => /* html */ `
   <style>
     ${defaultCss}
   </style>
-  ${defaultData(data)}
   ${defaultHtml(data)}
 `;
 


### PR DESCRIPTION
Remove `script` tag from API response. We'll use data attributes on the HTML instead of embedding JSON.