### PR TITLE
Fix host definition matching

### DIFF
--- a/src/shared/hosts.js
+++ b/src/shared/hosts.js
@@ -11,16 +11,5 @@ const url = require("./url");
  * A matching host definition, or undefined if none are found.
  */
 exports.matchHostDef = (host, hostDefs) => {
-  const pHostUrl = url.parse(host);
-
-  if (pHostUrl && hostDefs) {
-    return hostDefs.find((hostDef) =>
-      hostDef.urls.some((hostDefUrl) => {
-        const pHostDefUrl = url.parse(hostDefUrl);
-        return pHostDefUrl.hostname === pHostUrl.hostname;
-      })
-    );
-  } else {
-    return undefined;
-  }
+  return hostDefs?.find((hostDef) => url.findMatch(hostDef.urls, host));
 };


### PR DESCRIPTION
Fix up a problem with the way URLs are matched to their host definitions. Before, we would get conflicts when two host definitions were on the same domain.