### PR TITLE
Change schedule from 05:15 to 00:02

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -8,7 +8,7 @@ options /benefits
 post /event
 
 @scheduled
-airtable cron(15 12 * * ? *)
+airtable cron(2 7 * * ? *)
 
 @macros
 arc-macro-cors


### PR DESCRIPTION
Changes the daily schedule for content refreshes from Airtable. Currently, the scheduled job runs at 05:15 every morning. This PR changes that time to 00:02 (midnight plus two minutes). Note that this cron is expressed in UTC time.