### PR TITLE
Fix CodeQL code-scanning alerts

### DIFF
--- a/src/shared/icons.js
+++ b/src/shared/icons.js
@@ -1,7 +1,15 @@
 const html = (strings) => {
-  const content = strings[0];
-  const trimmed = content.replace(/<!--(.*?)-->|\s\B/gm, "").trim();
-  return trimmed;
+  let content = strings[0];
+  // Strip HTML comments — including ones that span multiple lines — repeating
+  // until the string stops changing so a partial "<!--" can't survive a single
+  // pass. ([\s\S] is used instead of "." so newlines inside comments match.)
+  let prev;
+  do {
+    prev = content;
+    content = content.replace(/<!--[\s\S]*?-->/g, "");
+  } while (content !== prev);
+  // Collapse insignificant whitespace, then trim.
+  return content.replace(/\s\B/g, "").trim();
 };
 
 exports.wiFi = html`

--- a/widget/serve/widget-server.js
+++ b/widget/serve/widget-server.js
@@ -1,8 +1,15 @@
 var express = require("express");
+var path = require("path");
 
 const widgetServer = (dir = "./") => {
   var app = express();
-  app.use(express.static(dir));
+  // Serve only the directories the preview page needs, rather than the whole
+  // widget folder, so unrelated files (server source, configs, node_modules)
+  // aren't exposed. local.html lives under /preview and loads the widget from
+  // /src; built bundles live under /dist.
+  app.use("/preview", express.static(path.join(dir, "preview")));
+  app.use("/src", express.static(path.join(dir, "src")));
+  app.use("/dist", express.static(path.join(dir, "dist")));
   app.listen(8080);
 
   console.log("\nSimple widget file server started.");


### PR DESCRIPTION
## Summary

Resolves all **3 open CodeQL code-scanning alerts**.

## Fixes

### `src/shared/icons.js` — 2× high
- `js/bad-tag-filter` + `js/incomplete-multi-character-sanitization`
- The `html()` SVG minifier stripped comments with `/<!--(.*?)-->|\s\B/gm`. `.*?` doesn't match newlines (multi-line comments survived) and a single pass could leave a partial `<!--`.
- **Fix:** use `[\s\S]*?` and loop the replacement until the string stops changing (the standard remediation for both rules).
- **Not exploitable** in practice — the helper only ever receives static, developer-authored SVG literals (consumed by `links.js`), never user input. But the regex was genuinely buggy.
- **Verified output is byte-identical for all 13 icons** (zero behavior change), and multi-line comments are now fully stripped.

### `widget/serve/widget-server.js` — 1× medium
- `js/exposure-of-private-files`
- The local preview dev server ran `express.static(dir)` on the entire widget folder, exposing server source, `package.json`, and `node_modules`.
- **Fix:** mount only the directories the preview needs — `/preview`, `/src`, `/dist`. The `dir` parameter is kept since `utils/stack-server.js` calls `widgetServer("./widget")`.

## Verification

- **icons.js:** new helper's output compared against the old for every export → 13/13 byte-identical; confirmed multi-line comments leave no residual `<!--`.
- **widget-server.js:** started the server — `/preview/local.html`, its assets, and `/src/cagov-benefits-recs.js` return **200**; `/serve/widget-server.js`, `/package.json`, `/node_modules/...`, and `/package-lock.json` now return **404**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)